### PR TITLE
Take hidden script_legend into account

### DIFF
--- a/src/jsTemplates/dca/tl_layout.php
+++ b/src/jsTemplates/dca/tl_layout.php
@@ -25,7 +25,7 @@
 
 $GLOBALS['TL_DCA']['tl_layout']['palettes']['default'] = str_replace
 (
-    '{script_legend}',
+    array('{script_legend}', '{script_legend:hide}'),
     '{script_legend},jsTemplates',
     $GLOBALS['TL_DCA']['tl_layout']['palettes']['default']
 );


### PR DESCRIPTION
In recent versions of Contao the script_legend is hidden by the ":hide"-flag inside the core's tl_layout.php.
To make the jsTemplate-module work with both variants (with and without ":hide"), I suggest to use an array of search-parameters in the str_replace section.
